### PR TITLE
Move source files location

### DIFF
--- a/ios/RCTRestart.podspec
+++ b/ios/RCTRestart.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = package["author"]
   s.platform     = :ios, "8.0"
   s.source       = { :git => package["repository"]["url"], :tag => "v#{package["version"]}" }
-  s.source_files = 'RCTRestart/**/*.{h,m}'
+  s.source_files = '**/*.{h,m}'
   s.requires_arc = true
 
   s.dependency "React"


### PR DESCRIPTION
podspec was looking in a subfolder RCTRestart for the source files, which would only work if the podspec was in the root directory.